### PR TITLE
performing some final integration testing

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -162,15 +162,13 @@ check_saml_signature = (xml, certificate, cb) ->
 
   signatures = xmlcrypto.xpath(doc, ".//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")
   return false unless signatures.length
+  signature = signatures[0]
 
   sig = new xmlcrypto.SignedXml()
   sig.keyInfoProvider = getKey: -> format_pem(certificate, 'CERTIFICATE')
 
-  for signature in signatures
-    sig.loadSignature signature.toString()
-    return false unless sig.checkSignature(xml)
-
-  return true
+  sig.loadSignature signature.toString()
+  return sig.checkSignature(xml)
 
 # Takes in an xml @dom containing a SAML Status and returns true if at least one status is Success.
 check_status_success = (dom) ->

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "async-ext": "~0.1.4",
     "debug": "^1.0.4",
     "underscore": "~1.6.0",
-    "xml-crypto": "^0.8.1",
+    "xml-crypto": "^0.8.2",
     "xml-encryption": "~0.7.0",
     "xml2js": "~0.4.1",
     "xmlbuilder": "~2.1.0",


### PR DESCRIPTION
- for the time being we only support the first assertion block in the callback (reflected by grabbing signatures[0]).
- upgrade to the version of xml-crypto that works.
